### PR TITLE
Add basic parsing of author pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ yarn add goodreads-parser
 
 ### Usage
 
+#### Parsing books
+
 First, import library
 
 ```js
@@ -55,6 +57,31 @@ Response:
 }
 ```
 
+#### Parsing author pages
+
+```js
+const GoodReadsParser = require("goodreads-parser");
+
+try {
+  const data = await GoodReadsParser.parseAuthorByUrl("https://www.goodreads.com/author/show/5780686.Liu_Cixin");
+  console.log("Author Data::", data);
+} catch (error) {
+  console.log("error", error);
+}
+```
+
+Response:
+
+```js
+Book Data:: {
+  name: 'Liu Cixin',
+  photo: 'https://images.gr-assets.com/authors/1454974329p5/5780686.jpg',
+  bio: 'Science Fiction fan and writer.Liu Cixin also appears as Cixin Liu',
+  id: '5780686',
+  url: 'https://www.goodreads.com/author/show/5780686.Liu_Cixin'
+}
+```
+
 ### API
 
 You can fetch book data by providing ISBN13 or just the url of the book in format like this: `https://www.goodreads.com/book/show/{ID}`
@@ -71,4 +98,11 @@ const result = await GoodReadsParser.parseByISBN13("123444");
 const result = await GoodReadsParser.parseByURL(
   "https://www.goodreads.com/book/show/36262331-the-three-body-problem"
 );
+```
+
+Author data can be fetched by providing the author URL form goodreads
+
+#### Author By Url
+```js
+const data = await GoodReadsParser.parseAuthorByUrl("https://www.goodreads.com/author/show/5780686.Liu_Cixin");
 ```

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 const axios = require("axios");
 const jsdom = require("jsdom");
-const { parseBookPage } = require("./utils");
+const { parseBookPage, parseAuthorPage } = require("./utils");
 const { JSDOM } = jsdom;
 
 const getResult = (result, response) => {
   const url = response.request.res.responseUrl
   let id = ''
   
-  let urlParts = url.split('book/show/')
+  let urlParts = url.split('/show/')
   if (urlParts.length > 1) {
     urlParts = urlParts[1]
     if (urlParts.split('.').length > 1) {
@@ -44,6 +44,18 @@ module.exports.parseByURL = async url => {
     const dom = new JSDOM(response.data);
     const { document } = dom.window;
     const result = parseBookPage(document);
+    return getResult(result, response)
+  } catch (error) {
+    throw error;
+  }
+};
+
+module.exports.parseAuthorByURL = async url => {
+  try {
+    const response = await axios.get(url);
+    const dom = new JSDOM(response.data);
+    const { document } = dom.window;
+    const result = parseAuthorPage(document);
     return getResult(result, response)
   } catch (error) {
     throw error;

--- a/utils.js
+++ b/utils.js
@@ -133,4 +133,32 @@ const parseBookPage = (document) => {
   return result;
 };
 
-module.exports = { parseBookPage };
+const parseAuthorPage = (document) => {
+  const name = parseElementValue({
+    document,
+    query: "h1.authorName",
+    content: "textContent",
+  });
+
+  const photo = parseElementValue({
+    document,
+    query: ".authorLeftContainer > a > img",
+    content: "src",
+  });
+
+  const bio = parseElementValue({
+    document,
+    query: ".aboutAuthorInfo > span:last-of-type",
+    content: "textContent",
+  });
+
+  const result = {
+    name,
+    photo,
+    bio
+  };
+
+  return result;
+};
+
+module.exports = { parseBookPage, parseAuthorPage };


### PR DESCRIPTION
This PR adds a new parseAuthorByURL method to parse basic data from an
authors page on goodreads.  This method will return the following data:

{
  name:
  photo:
  bio:
  id:
  url:
}

The bio field will only be populated if it exists on the page (some
author pages have a blog post instead of a bio, etc)